### PR TITLE
Add cflinuxfs5 support for Java buildpack

### DIFF
--- a/jobs/java-buildpack/spec
+++ b/jobs/java-buildpack/spec
@@ -3,6 +3,7 @@ name: java-buildpack
 templates: {}
 
 packages:
+- java-buildpack-cflinuxfs5
 - java-buildpack-cflinuxfs4
 
 properties: {}

--- a/packages/java-buildpack-cflinuxfs5/packaging
+++ b/packages/java-buildpack-cflinuxfs5/packaging
@@ -1,0 +1,3 @@
+set -e -x
+
+cp java-buildpack/java?buildpack-cflinuxfs5-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/java-buildpack-cflinuxfs5/spec
+++ b/packages/java-buildpack-cflinuxfs5/spec
@@ -1,0 +1,4 @@
+---
+name: java-buildpack-cflinuxfs5
+files:
+- java-buildpack/java?buildpack-cflinuxfs5-v*.zip


### PR DESCRIPTION
This commit adds cflinuxfs5 (Ubuntu 24.04 noble) stack support to the java-buildpack BOSH release, following the same pattern used for cflinuxfs4.

Changes:
- Create packages/java-buildpack-cflinuxfs5/spec - package specification
- Create packages/java-buildpack-cflinuxfs5/packaging - build script
- Update jobs/java-buildpack/spec to reference cflinuxfs5 package

Both cflinuxfs4 and cflinuxfs5 packages will be included in future releases, enabling operators to deploy Java applications on either stack during the migration period from jammy (cflinuxfs4) to noble (cflinuxfs5).

The next BOSH release will include the cflinuxfs5 package, making it available for Cloud Foundry deployments.